### PR TITLE
fix: do not skip initial loadedmetadata event

### DIFF
--- a/src/ncoverlay/patcher.ts
+++ b/src/ncoverlay/patcher.ts
@@ -168,11 +168,11 @@ export class NCOPatcher {
       await this.#nco.state.set('status', 'ready')
     }
 
-    let prev = 0
+    let prev: number | null = null
 
     this.#nco.addEventListener('loadedmetadata', async function () {
       const now = performance.now()
-      const isSkip = now - prev < 1000
+      const isSkip = prev !== null && now - prev < 1000
 
       prev = now
 


### PR DESCRIPTION
## 概要

`loadedmetadata` の debounce ロジックを修正し、初回イベントが必ず処理されるようにします。

短時間（1000ms以内）に連続発火した `loadedmetadata` の重複処理を抑制する既存の挙動は維持しています。

Fixes #9

## 背景

これまでは debounce 用の前回時刻を `0` で初期化していました。

そのため、ページ初期化直後（`performance.now()` がまだ 1000ms 未満）に最初の `loadedmetadata` が処理されると、`performance.now() - prev < 1000` が `true` となり、初回イベントにもかかわらずスキップされ、`loadInfo()` / `autoSearch()` が実行されない場合がありました。

前回時刻を `null` で初期化することで初回を明示的に区別し、「前回時刻が存在する場合のみ」 debounce のスキップ判定の対象とします。

## 変更点

- `loadedmetadata` の前回時刻を `null` で初期化。
- 1000ms のスキップ判定を、少なくとも1回 `loadedmetadata` を処理した後にのみ適用。
- 既存の重複イベント抑制（debounce）の挙動は維持。

## 検証

- [x] `bun run compile`
- [x] `bun run check`
- [x] `bun run build:chrome`
- [ ] 実機での再生確認（未実施）
